### PR TITLE
Remove the "skip init schema" stuff

### DIFF
--- a/odoo-13/dev-server.sh
+++ b/odoo-13/dev-server.sh
@@ -59,13 +59,6 @@ postgres_init() {
 
     postgres --single -D "$PGDATA_NEW" postgres < "${PG}/../data/prepare.sql" >/dev/null
 
-    if [ ! "$SKIP_INIT_SCHEMA" ]; then
-        $START_POSTGRES -D "$PGDATA_NEW" &
-        await_postgres
-        kill $!
-        wait $! || true >/dev/null
-    fi
-
     mv "$PGDATA_NEW" "$PGDATA"
     sync
 }

--- a/odoo-14/dev-server.sh
+++ b/odoo-14/dev-server.sh
@@ -59,13 +59,6 @@ postgres_init() {
 
     postgres --single -D "$PGDATA_NEW" postgres < "${PG}/../data/prepare.sql" >/dev/null
 
-    if [ ! "$SKIP_INIT_SCHEMA" ]; then
-        $START_POSTGRES -D "$PGDATA_NEW" &
-        await_postgres
-        kill $!
-        wait $! || true >/dev/null
-    fi
-
     mv "$PGDATA_NEW" "$PGDATA"
     sync
 }

--- a/odoo-15/dev-server.sh
+++ b/odoo-15/dev-server.sh
@@ -64,13 +64,6 @@ postgres_init() {
 
     postgres --single -D "$PGDATA_NEW" postgres < "${PG}/../data/prepare.sql" >/dev/null
 
-    if [ ! "$SKIP_INIT_SCHEMA" ]; then
-        $START_POSTGRES -D "$PGDATA_NEW" &
-        await_postgres
-        kill $!
-        wait $! || true >/dev/null
-    fi
-
     mv "$PGDATA_NEW" "$PGDATA"
     sync
 }

--- a/odoo-16/dev-server.sh
+++ b/odoo-16/dev-server.sh
@@ -64,13 +64,6 @@ postgres_init() {
 
     postgres --single -D "$PGDATA_NEW" postgres < "${PG}/../data/prepare.sql" >/dev/null
 
-    if [ ! "$SKIP_INIT_SCHEMA" ]; then
-        $START_POSTGRES -D "$PGDATA_NEW" &
-        await_postgres
-        kill $!
-        wait $! || true >/dev/null
-    fi
-
     mv "$PGDATA_NEW" "$PGDATA"
     sync
 }


### PR DESCRIPTION
When SKIP_INIT_SCHEMA was unset, we'd spin up a postgres on the new data directory, but it wasn't actually used.  Drop this, as the loading of the initial schema is already handled by the prepare.sql in the postgres --single call preceding this block.  This is likely the reason sometimes Postgres doesn't want to shut down cleanly, as the kill command in this block might trigger an unclean shutdown.